### PR TITLE
Set org-mode as default content type

### DIFF
--- a/src/runtime/rest/api.org
+++ b/src/runtime/rest/api.org
@@ -83,7 +83,10 @@ for passing it to =System Interface=.
             'overview': data_dict['experiment']['overview'],
             'sections': data_dict['experiment']['sections']
         }
-        content = data_dict['content-type']
+	if 'content-type' in data_dict.keys():
+	    content = data_dict['content-type']
+	else:
+	    content = 'org'    
 #+END_SRC
 
 And finally pass the converted data to the =System Interface= for working on the data.
@@ -206,8 +209,8 @@ def create_openedx_lab():
     if request.method == 'POST':
         data_json = request.get_json()
         lab_dict = yaml.safe_load(json.dumps(data_json))
-        lab_id = lab_dict['course']['id']
-        dname = lab_dict['course']['display_name'].replace(" ", "-")
+        lab_id = lab_dict['experiment']['id']
+        dname = lab_dict['experiment']['name'].replace(" ", "-")
         labname = dname + "-" + lab_id
         try:
             SystemInterface.create_openedx_lab(labname, data_json)

--- a/src/sitemap.org
+++ b/src/sitemap.org
@@ -2,6 +2,21 @@
 
    + deployment
      + [[file:deployment/index.org][Deploying the application on a server]]
+   + githubv3
+     + github
+       + [[file:githubv3/github/user.org][REST Interface for translators]]
+       + [[file:githubv3/github/requester.org][REST Interface for translators]]
+       + [[file:githubv3/github/repository.org][REST Interface for translators]]
+       + [[file:githubv3/github/organization.org][REST Interface for translators]]
+       + [[file:githubv3/github/logger.org][REST Interface for translators]]
+       + [[file:githubv3/github/iterator.org][REST Interface for translators]]
+       + [[file:githubv3/github/index.org][REST Interface for translators]]
+       + [[file:githubv3/github/github_urls.org][REST Interface for translators]]
+       + [[file:githubv3/github/github_exception.org][REST Interface for translators]]
+       + [[file:githubv3/github/files.org][REST Interface for translators]]
+       + [[file:githubv3/github/directory.org][REST Interface for translators]]
+       + [[file:githubv3/github/base_class.org][REST Interface for translators]]
+     + [[file:githubv3/index.org][Runtime of Application]]
    + openedx
      + data-model
        + [[file:openedx/data-model/index.org][Data Model for Content Delivery Adapters]]


### PR DESCRIPTION
The API `create_experiment` takes default `content-type` as `org` if not mentioned in the labspec.

Closes [#11](https://github.com/vlead/vlabs-platform/issues/11) in `vlabs-platform`.